### PR TITLE
minor fixes

### DIFF
--- a/controls/V-75445.rb
+++ b/controls/V-75445.rb
@@ -67,10 +67,7 @@ Run the following command to lock the root account:
 
   describe.one do
     describe shadow.where(user: 'root') do
-      its('passwords') { should include '!' }
-    end
-    describe shadow.where(user: 'root') do
-      its('passwords') { should include '*' }
+      its('passwords') { should include '!*' }
     end
   end
 end

--- a/controls/V-75529.rb
+++ b/controls/V-75529.rb
@@ -49,6 +49,6 @@ Unattended-Upgrade::Remove-Unused-Dependencies \"true\";"
   end
 
   describe command('grep -i remove-unused /etc/apt/apt.conf.d/50unattended-upgrades').stdout.strip do
-    it { should match /^\s*([^\s]*::Remove-Unused-Dependencies)\s*\\"true\\"\s*;$/ }
+    it { should match /^\s*([^\s]*::Remove-Unused-Dependencies)\s*\"true\"\s*;$/ }
   end
 end

--- a/controls/V-75789.rb
+++ b/controls/V-75789.rb
@@ -57,7 +57,7 @@ the audit daemon, run the following command:
 
 # sudo systemctl restart auditd.service"
 
-  @audit_file = '/usr/bin/pam_timestamp_check'
+  @audit_file = '/usr/sbin/pam_timestamp_check'
 
   audit_lines_exist = !auditd.lines.index { |line| line.include?(@audit_file) }.nil?
   if audit_lines_exist

--- a/controls/V-75797.rb
+++ b/controls/V-75797.rb
@@ -53,7 +53,7 @@ running the following command:
 
 # sudo apt-get remove telnetd"
 
-  describe package('telnet') do
+  describe package('telnetd') do
     it { should_not be_installed }
   end
 end


### PR DESCRIPTION
- **V-75445**: locking root password by `passwd -l root` set paasowrd to `!*`. 
```
# grep root /etc/shadow
root:!*:18472:0:99999:7:::
```

- **V-75529**: Remove extra `\`s around `true`
```
# ruby -e 'puts /^\s*([^\s]*::Remove-Unused-Dependencies)\s*\\"true\\"\s*;$/.match("Unattended-Upgrade::Remove-Unused-Dependencies \"true\"")'

# ruby -e 'puts /^\s*([^\s]*::Remove-Unused-Dependencies)\s*\"true\"\s*;$/.match("Unattended-Upgrade::Remove-Unused-Dependencies \"true\";")'
Unattended-Upgrade::Remove-Unused-Dependencies "true";
```

- **V-75789**: Path to `pam_timestamp_check` is `/usr/sbin/pam_timestamp_check`

```
# which pam_timestamp_check
/usr/sbin/pam_timestamp_check
```

- **V-75797**: Rule should check for `telnetd` instead of `telnet`